### PR TITLE
Added an alternative installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Install (Visual Studio Code)
 
 1. In the [Releases page](https://github.com/qexat/qexat-theme/releases), download the latest file `qexat-theme-<version>.vsix`.
-2. In VS Code, press `Ctrl` + `Shift` + `P` and start typing [`Extensions: Install from VSIX...`](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix) until it gets suggested[^1]. If this does not work, try using [`Developer: Install Extension from Location...`](https://code.visualstudio.com/updates/v1_74#_install-an-extension-located-on-disk).
+2. In VS Code, press `Ctrl` + `Shift` + `P` and start typing [`Extensions: Install from VSIX...`](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix) until it gets suggested. If this does not work, try using [`Developer: Install Extension from Location...`](https://code.visualstudio.com/updates/v1_74#_install-an-extension-located-on-disk).[^1]
 3. Choose the previously downloaded file. That should install it automatically.
 4. And voilà!
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 ## Install (Visual Studio Code)
 
 1. In the [Releases page](https://github.com/qexat/qexat-theme/releases), download the latest file `qexat-theme-<version>.vsix`.
-2. In VS Code, press `Ctrl` + `Shift` + `P` and start typing [`Developer: Install Extension from Location...`](https://code.visualstudio.com/updates/v1_74#_install-an-extension-located-on-disk) until it gets suggested\*.
+2. In VS Code, press `Ctrl` + `Shift` + `P` and start typing [`Developer: Install Extension from Location...`](https://code.visualstudio.com/updates/v1_74#_install-an-extension-located-on-disk) until it gets suggested[^1]. If this does not work, try using [`Extensions: Install from VSIX...`](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix).
 3. Choose the previously downloaded file. That should install it automatically.
 4. And voilà!
 
-> \* If the command does not show up, check if VS Code is up to date.
+[^1]: If the command does not show up, check if VS Code is up to date.
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Install (Visual Studio Code)
 
 1. In the [Releases page](https://github.com/qexat/qexat-theme/releases), download the latest file `qexat-theme-<version>.vsix`.
-2. In VS Code, press `Ctrl` + `Shift` + `P` and start typing [`Developer: Install Extension from Location...`](https://code.visualstudio.com/updates/v1_74#_install-an-extension-located-on-disk) until it gets suggested[^1]. If this does not work, try using [`Extensions: Install from VSIX...`](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix).
+2. In VS Code, press `Ctrl` + `Shift` + `P` and start typing [`Extensions: Install from VSIX...`](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix) until it gets suggested[^1]. If this does not work, try using [`Developer: Install Extension from Location...`](https://code.visualstudio.com/updates/v1_74#_install-an-extension-located-on-disk).
 3. Choose the previously downloaded file. That should install it automatically.
 4. And voilà!
 


### PR DESCRIPTION
The new command didn't let me choose a `.vsix` file for some reason, so I tried an older one which worked: `Extensions: Install from VSIX...`.

Also changed the "troubleshooting note" to a reference link.